### PR TITLE
Boss page improvements – WIP

### DIFF
--- a/src/parsers/dictionary.ts
+++ b/src/parsers/dictionary.ts
@@ -312,7 +312,7 @@ export const CATEGORIES: CollectableCategory[] = [
   ],
   },
   {
-    name: 'Bosses [WIP]',
+    name: 'Bosses',
     description: 'Bosses',
     items: [
       { name: 'Moss Mother',                whichAct: 1, completionPercent: 0, prereqs: [], location: 'Appearing in the Ruined Chapel at the end of Moss Grotto.', parsingInfo: { type: 'flag', internalId: 'defeatedMossMother' }, mapLink: 'https://mapgenie.io/hollow-knight-silksong/maps/pharloom?locationIds=476904' },

--- a/src/tabs/BossesTab.tsx
+++ b/src/tabs/BossesTab.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import type { TabRenderProps } from "./types";
 import { CATEGORIES, isItemUnlockedInPlayerSave } from "../parsers/dictionary";
 
-const BOSSES_CATEGORY_NAME = "Bosses [WIP]";
+const BOSSES_CATEGORY_NAME = "Bosses";
 
 export function BossesTab({ parsedJson, decrypted }: TabRenderProps) {
   if (!decrypted || !parsedJson) {
@@ -75,7 +75,7 @@ export function getBossesExtra({ parsedJson, decrypted }: { parsedJson: unknown;
     return null;
   }
 
-  const bossCategory = CATEGORIES.find(cat => cat.name === "Bosses [WIP]");
+  const bossCategory = CATEGORIES.find(cat => cat.name === "Bosses");
   const bosses = bossCategory?.items ?? [];
 
   if (bosses.length === 0) {

--- a/src/tabs/index.tsx
+++ b/src/tabs/index.tsx
@@ -82,7 +82,7 @@ export const tabDefinitions: TabDefinition[] = [
   },
   {
     id: "Bosses",
-    label: "Bosses [WIP]",
+    label: "Bosses",
     render: props => <BossesTab {...props} />,
     getExtra: getBossesExtra,
   },


### PR DESCRIPTION
Update for: #3 

Status:
- [x] All bosses added ([confirmed:](https://hollowknight.wiki/w/Category:Bosses_(Silksong)) Total 44 bosses )
- [x] Map Locations updated
- [x] Proper Act number
- [x] Boss Location
- [x] InternalId's added(Unable to find Shakra's internal id)

