### PR TITLE
Add a custom variant to fix hovering issue on some devices

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@custom-variant hover (&:hover);
 html {
   scrollbar-gutter: stable both-edges;
   background-color: black;


### PR DESCRIPTION
Hi,

I have had an issue with the hovering over the blurred out sections on the page. It would sometimes on some devices not unblur. I had a look online for a solution and stumbled upton this:

https://tailwindcss.com/docs/upgrade-guide#hover-styles-on-mobile

So this PR adds the 

```css
@custom-variant hover (&:hover);
```

to the main css file, which fixed it for me.