### PR TITLE
Fixed macOS save file path

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,7 +46,7 @@ const PLATFORM_OPTIONS: PlatformOption[] = [
   {
     id: "macOS",
     label: "macOS",
-    path: "~/Library/Application Support/Team Cherry/Hollow Knight Silksong/",
+    path: "~/Library/Application Support/unity.Team-Cherry.Silksong/",
   },
   {
     id: "Linux(Steamdeck)",


### PR DESCRIPTION
Thanks for developing this project!

This PR fixes the macOS save file path.

- Previous path:
  `~/Library/Application Support/Team Cherry/Hollow Knight Silksong/`

- Correct path (according to the [official website](https://hollowknightsilksong.com/help#:~:text=save%20file.-,PC%20Save%20File%20Locations,-Windows%3A%20%25USERPROFILE)):
  `~/Library/Application Support/unity.Team-Cherry.Silksong/`

<img width="1636" height="884" alt="image" src="https://github.com/user-attachments/assets/ca893fa2-af89-4e68-99c1-40f0aedba709" />

