### PR TITLE
Move Google Analytics to environment variables with conditional loading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# To disable Google Analytics, leave the value empty after the = sign:
+# VITE_GA_MEASUREMENT_ID=
+
+VITE_GA_MEASUREMENT_ID=your-ga-measurement-id-here
+
+# Instructions:
+# 1. Copy this file: cp .env.example .env
+# 2. Replace 'your-ga-measurement-id-here' with your actual Google Analytics measurement ID
+# 3. For production deployment, set this environment variable in your hosting platform
+# 4. The .env file is ignored by git to keep your credentials secure

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# Environment variables
+.env
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/index.html
+++ b/index.html
@@ -7,14 +7,21 @@
     <title>Silksong Completionist · Track Your Hollow Knight: Silksong Progress</title>
     <meta name="description" content="Hollow Knight: Silksong Save Analyzer / Tracker: Track and obtain every achievement, tool, skill, and secret in Hollow Knight: Silksong. Perfect for completionists! Simply upload your save file to get started.">
 
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-RN3TLJS55G"></script>
+    <!-- Google tag (gtag.js) - Only load if GA measurement ID is provided -->
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-RN3TLJS55G');
+      const gaMeasurementId = '%VITE_GA_MEASUREMENT_ID%';
+      if (gaMeasurementId && gaMeasurementId !== 'your-ga-measurement-id-here') {
+        const script = document.createElement('script');
+        script.async = true;
+        script.src = `https://www.googletagmanager.com/gtag/js?id=${gaMeasurementId}`;
+        document.head.appendChild(script);
+        
+        // Initialize Google Analytics
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', gaMeasurementId);
+      }
     </script> 
   </head>
   <body>


### PR DESCRIPTION
- Replace hardcoded GA ID with VITE_GA_MEASUREMENT_ID environment variable
- Add conditional script loading to prevent GA in development
- Add .env.example with setup instructions and ignore .env file