### PR TITLE
Improved Materium category description

### DIFF
--- a/src/components/features/TabContainer/GenericContent.tsx
+++ b/src/components/features/TabContainer/GenericContent.tsx
@@ -44,7 +44,11 @@ export function GenericContent({
 
   return (
     <>
-      <CategoryHeader title={tabLabel || category.name} description={category.description} />
+      <CategoryHeader
+        title={tabLabel || category.name}
+        description={category.description}
+        descriptionMarkup={category.descriptionMarkup}
+      />
 
       <StatusBar
         inShowEverythingMode={inShowEverythingMode}

--- a/src/components/features/TabContainer/shared/CategoryHeader.tsx
+++ b/src/components/features/TabContainer/shared/CategoryHeader.tsx
@@ -3,15 +3,21 @@ import type { ReactNode } from "react";
 interface CategoryHeaderProps {
   title: string;
   description?: string | ReactNode;
+  descriptionMarkup?: ReactNode | ((showSpoilers?: boolean, sectionData?: unknown) => ReactNode);
 }
 
-export function CategoryHeader({ title, description }: CategoryHeaderProps) {
+export function CategoryHeader({ title, description, descriptionMarkup }: CategoryHeaderProps) {
   return (
     <div className="bg-gray-800/30 border-2 border-gray-600/30 rounded-t-lg px-4 py-3 mb-0">
       <h2 className="text-xl font-bold text-blue-200">{title}</h2>
       {description && description !== title && (
         <div className="text-sm text-gray-300 mt-1">
           {typeof description === "string" ? <p>{description}</p> : description}
+        </div>
+      )}
+      {descriptionMarkup && (
+        <div className="text-sm text-gray-300 mt-1">
+          {typeof descriptionMarkup === "function" ? descriptionMarkup() : descriptionMarkup}
         </div>
       )}
     </div>

--- a/src/dictionary/categories/materium.tsx
+++ b/src/dictionary/categories/materium.tsx
@@ -2,7 +2,17 @@ import type { TrackableCategory } from "../types";
 
 export const materium: TrackableCategory = {
   name: "Materium",
-  description: "Materials found throughout Hornet's journey in Pharloom.",
+  descriptionMarkup: (
+    <>
+      <span>Materials found throughout Hornet's journey in Pharloom.</span>
+      <br />
+      <br />
+      <span>
+        These are only tracked once the Materium is assembled and the items are displayed under Materium in-game;
+        regardless of when they are obtained, and regardless of whether or not they're available in your inventory.
+      </span>
+    </>
+  ),
   sections: [
     {
       items: [

--- a/src/dictionary/normalizer.ts
+++ b/src/dictionary/normalizer.ts
@@ -13,6 +13,7 @@ export function normalizeDictionary(categories: TrackableCategory[]): Normalised
     const normalizedCategory: NormalizedCategory = {
       name: category.name,
       description: category.description,
+      descriptionMarkup: category.descriptionMarkup,
       totalPercent: 0,
       totalCount: 0,
       sections: {},

--- a/src/dictionary/types.ts
+++ b/src/dictionary/types.ts
@@ -72,7 +72,8 @@ export type CategorySection = {
 
 export type TrackableCategory = {
   name: string;
-  description: string;
+  description?: string;
+  descriptionMarkup?: ReactNode | ((showSpoilers?: boolean, sectionData?: unknown) => ReactNode);
   sections: CategorySection[];
 };
 
@@ -105,7 +106,8 @@ export type NormalizedSection = {
 
 export type NormalizedCategory = {
   name: string;
-  description: string;
+  description?: string;
+  descriptionMarkup?: ReactNode | ((showSpoilers?: boolean, sectionData?: unknown) => ReactNode);
   totalPercent: number;
   totalCount: number;
   sections: Record<NormalizedSection["name"], NormalizedSection>;


### PR DESCRIPTION
<img width="1506" height="250" alt="image" src="https://github.com/user-attachments/assets/7cd2a252-8966-4ec0-acb9-f86a09470bab" />

Fixes #58 

- Added descriptionMarkup support to CategoryHeader
- Made description field optional in categories, in favor of descriptionMarkup
- Converted materium.ts to materium.tsx with JSX-based descriptionMarkup
- Updated normalizer to include descriptionMarkup in normalized categories
- Added descriptionMarkup prop to TrackableCategory and NormalizedCategory types
- Updated GenericContent to pass descriptionMarkup to CategoryHeader
- Updated CategoryHeader to render descriptionMarkup when available