### PR TITLE
Remove deprecated TypeScript baseUrl usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@ Comprehensively tracks everything that contributes to 100% completion in Hollow 
   - Silk Hearts
   - Cloak Abilities _(these don't contribute to 100% completion)_
   - Ancestral Arts
-  - Other (Unique) Abilities
-    - Sylphsong
-    - Everbloom
+  - Other Abilities
 - **Upgrades**
   - Needle Upgrades
   - Tool Pouch Upgrades

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     },
 
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",


### PR DESCRIPTION
This PR removes the deprecated TypeScript `baseUrl` compiler option and updates the `@/*` path alias to use an explicit relative mapping instead. Existing import behaviour remains unchanged under bundler resolution.

Also includes a small README cleanup/update.